### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/functions"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"
+    groups:
+      firebase:
+        dependency-type: "production"
+        patterns:
+          - "firebase-*"
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
## Summary

Dependabot からの PR ノイズを減らすため、`.github/dependabot.yml` を新規追加します。

- **月次スケジュール** で version update をチェック（緊急のセキュリティアップデートは設定に関わらず即時で動作）
- **直接依存のみ** を更新対象にし、transitive 依存の lockfile-only PR（最近の #38, #39 のようなもの）を抑制
- `firebase-*` パッケージ群と dev dependencies をグループ化して PR 数を削減

## 想定される動作

| パッケージ | グループ |
|---|---|
| `axios` | 単独 PR |
| `firebase-admin`, `firebase-functions` | `firebase` グループにまとめて1 PR |
| `firebase-functions-test`, `tslint`, `typescript` | `dev-dependencies` グループにまとめて1 PR |

通常時の PR 数: 最大 3 件／月

## 補足

- セキュリティアラート起点の PR は `schedule.interval` の影響を受けないため、緊急度の高い脆弱性対応 PR は引き続き即時で作成されます。
- `ignore` は使用していないため、脆弱性 PR が抑止されることはありません。

## Test plan

- [ ] マージ後、GitHub の Insights → Dependency graph → Dependabot に新しい設定が認識されているか確認
- [ ] 既存 OPEN PR への影響がないか確認
- [ ] 次回更新発生時に、想定通りグループ化された PR が来るか観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)