### PR TITLE
Limit Dependabot grouping to minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,11 @@ updates:
         dependency-type: "production"
         patterns:
           - "firebase-*"
+        update-types:
+          - "minor"
+          - "patch"
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

PR #42 でメジャーバージョンの bump（TypeScript 5 → 6、firebase-functions-test 0.x → 3.x）が同じグループに束ねられて来たため、グルーピング設定を見直します。

各グループに `update-types: [minor, patch]` を追加し、**メジャー更新は個別 PR で来る**ようにします。

## 期待される動作

| シナリオ | 結果 |
|---|---|
| TypeScript 5.7 → 5.8 (minor) | `dev-dependencies` グループに含まれる |
| TypeScript 5.7 → 6.0 (major) | **個別 PR** で来る |
| firebase-admin 13.x → 13.y (minor) | `firebase` グループに含まれる |
| firebase-admin 13.x → 14.0 (major) | **個別 PR** で来る |

メジャー更新が単独 PR で来ることで、ビルド検証・互換性確認をやりやすくなります。

## Test plan

- [ ] マージ後、Dependabot Insights で新設定が認識されているか確認
- [ ] PR #42 をクローズし、次回更新時にメジャー更新が分離されてくるか観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)