### PR TITLE
Ignore non-security major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     open-pull-requests-limit: 5
     allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       firebase:
         dependency-type: "production"


### PR DESCRIPTION
## Summary

メジャーバージョン更新は breaking change を含むことが多く、機能追従のためだけに頻繁にレビューするには負担が大きいので、**Dependabot から PR が作られないように抑制**します。

ただし「**セキュリティ修正がメジャー更新でしか入手できないケース**」は引き続き Security PR として作成されるよう、`ignore` を使用します（公式に [Ignore Conditions Do Not Apply to Security Updates](https://github.com/dependabot/dependabot-core) のテストで保証されている挙動）。

## 変更

```diff
     allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
```

## 期待される動作

| シナリオ | 結果 |
|---|---|
| TypeScript 5.7 → 5.8 (minor) | dev-dependencies グループで PR 来る |
| TypeScript 5.7 → 6.0 (major, 通常更新) | **PR 来ない** |
| firebase-admin 13.x → 14.0 (major, 通常更新) | **PR 来ない** |
| CVE 対応で 5.7 → 5.7.4 (patch security) | Security PR 来る |
| CVE 対応で **6.x でしか修正されない** (major security) | **Security PR 来る** |

## 補足: 既存ルールとの併用効果

| ルール | 効果 |
|---|---|
| `allow: dependency-type: direct` | Transitive の通常 PR は除外（セキュリティは来る） |
| `groups (update-types: minor, patch)` | minor/patch のグループ化 |
| **NEW: `ignore: version-update:semver-major`** | major の通常 PR を除外（セキュリティは来る） |

3つ組み合わせて、運用ノイズを最小化しつつ脆弱性対応は確実に届く形になります。

## Test plan

- [ ] マージ後、現状開いている PR #48 (typescript 5→6, major) をクローズして再作成されないか確認
- [ ] 次回 Dependabot 実行時にメジャー更新の通常 PR が作成されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)